### PR TITLE
Fix098126

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+/NerdNewsNavigator2/Services/PodcastData.cs

--- a/NerdNewsNavigator2/NerdNewsNavigator2.csproj
+++ b/NerdNewsNavigator2/NerdNewsNavigator2.csproj
@@ -23,7 +23,7 @@
 
 		<!-- Versions -->
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-		<ApplicationVersion>7</ApplicationVersion>
+		<ApplicationVersion>8</ApplicationVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">16.1</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.2</SupportedOSPlatformVersion>

--- a/NerdNewsNavigator2/Platforms/Windows/app.manifest
+++ b/NerdNewsNavigator2/Platforms/Windows/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.1" name="NerdNewsNavigator2.WinUI.app"/>
+  <assemblyIdentity version="1.0.0.3" name="NerdNewsNavigator2.WinUI.app"/>
 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>

--- a/NerdNewsNavigator2/View/LivePage.xaml.cs
+++ b/NerdNewsNavigator2/View/LivePage.xaml.cs
@@ -85,10 +85,7 @@ public partial class LivePage : ContentPage
     {
         var masterPlaylist = MasterPlaylist.LoadFromText(m3UString);
         var list = masterPlaylist.Streams.ToList();
-        foreach (var item in list)
-        {
-            Add(item);
-        }
+        Add(list);
         return list[list.FindIndex(x => x.Resolution.Height == 720)].Uri;
     }
 
@@ -96,14 +93,17 @@ public partial class LivePage : ContentPage
     /// Method creates <see cref="List{T}"/> of URL's from <see cref="M3U8Parser.ExtXType.StreamInf"/>
     /// </summary>
     /// <param name="item"></param>
-    private void Add(M3U8Parser.ExtXType.StreamInf item)
+    private void Add(List<M3U8Parser.ExtXType.StreamInf> item)
     {
-        var temp = new YoutubeResolutions
+        item?.ForEach(x =>
         {
-            Title = $"{item.Resolution.Height}P",
-            Url = item.Uri.ToString()
-        };
-        Items.Add(temp);
+            var temp = new YoutubeResolutions
+            {
+                Title = $"{x.Resolution.Height}P",
+                Url = x.Uri.ToString()
+            };
+            Items.Add(temp);
+        });
     }
     /// <summary>
     /// Method returns the Live stream M3U Url from Youtube ID.

--- a/NerdNewsNavigator2/View/LivePage.xaml.cs
+++ b/NerdNewsNavigator2/View/LivePage.xaml.cs
@@ -42,17 +42,18 @@ public partial class LivePage : ContentPage
         {
             return;
         }
-        _ = LoadVideo();
+        var item = "https://www.youtube.com/user/twit";
+        _ = LoadVideo(item);
     }
 
     /// <summary>
     /// Method Starts <see cref="MediaElement"/> Playback.
     /// </summary>
     /// <returns></returns>
-    private async Task LoadVideo()
+    private async Task LoadVideo(string url)
     {
         mediaElement.IsYoutube = true;
-        var m3u = await ParseVideoIdAsync("https://www.youtube.com/user/twit");
+        var m3u = await ParseVideoIdAsync(url);
         if (m3u != string.Empty)
         {
             mediaElement.Source = ParseM3UPLaylist(await GetM3U_Url(m3u));


### PR DESCRIPTION
Live streams now fixed! No more having to manually edit live streams. It now uses https://www.youtube.com/twit/live to resolve live stream and not some video id.