### PR TITLE
Quick fix for back button dissapearing on video player on

### DIFF
--- a/NerdNewsNavigator2/View/VideoPlayerPage.xaml
+++ b/NerdNewsNavigator2/View/VideoPlayerPage.xaml
@@ -14,6 +14,6 @@
     Unloaded="ContentPage_Unloaded">
     <media:MediaControl x:Name="mediaElement" IsYoutube="False" />
     <Shell.BackButtonBehavior>
-        <BackButtonBehavior IsEnabled="True" IsVisible="{OnPlatform WinUI=False, Android=false, Default=True}" />
+        <BackButtonBehavior IsEnabled="True" IsVisible="{OnPlatform WinUI=False, Default=True}" />
     </Shell.BackButtonBehavior>
 </ContentPage>


### PR DESCRIPTION
Android